### PR TITLE
Fixes for comment types that look like valid regexes

### DIFF
--- a/plugin/double-tap.vim
+++ b/plugin/double-tap.vim
@@ -50,7 +50,6 @@ function! s:Detect_empty_comment()
     let s:commStart[&ft] = substitute(&commentstring, "%s.*$", "", "")
     let s:commStart[&ft] = substitute(s:commStart[&ft], "\s*","","")
     let s:commStart[&ft] = escape(s:commStart[&ft],'/\')
-    :echom s:commStart[&ft]
   endif
   let line = getline('.')
   if s:commStart[&ft] != '' && line =~ '\V\^\s\*'. s:commStart[&ft] . '\s\*\$'

--- a/plugin/double-tap.vim
+++ b/plugin/double-tap.vim
@@ -35,9 +35,6 @@ endif
 let g:loaded_doubletap = 1
 " }}}
 
-let s:pattern = '\([b,]\|^\):\zs\([^,]\+\)' " This patterns finds the wanted
-                                         " item in 'comments'
-
 let s:commStart = {} " dict to hold the comment starters using
                      " the current filetype as key
 
@@ -50,10 +47,13 @@ function! s:Detect_empty_comment()
   endif
   " Captures the comment starter if necessary; only once per filetype
   if !has_key(s:commStart, &ft)
-    let s:commStart[&ft] = matchstr(&comments, s:pattern)
+    let s:commStart[&ft] = substitute(&commentstring, "%s.*$", "", "")
+    let s:commStart[&ft] = substitute(s:commStart[&ft], "\s*","","")
+    let s:commStart[&ft] = escape(s:commStart[&ft],'/\')
+    :echom s:commStart[&ft]
   endif
   let line = getline('.')
-  if s:commStart[&ft] != '' && line =~ '^\s*'. s:commStart[&ft] . '\s*$'
+  if s:commStart[&ft] != '' && line =~ '\V\^\s\*'. s:commStart[&ft] . '\s\*\$'
     return "\<C-U>"
   else
     return "\<CR>"


### PR DESCRIPTION
Basically, comment start string is now escaped @ L52.

Also in the process I discovered that previous matchstr against &comments returned \* instead of // needed, so I changed the whole process to use (slightly modified) &commentstring.

Enabled nomagic mode for regex as well.

I did not test it with anything except for VimL, shell scripts and Go comments, so any testing is encouraged : )
