### PR TITLE
Comment list scan

### DIFF
--- a/plugin/double-tap.vim
+++ b/plugin/double-tap.vim
@@ -35,8 +35,8 @@ endif
 let g:loaded_doubletap = 1
 " }}}
 
-let s:pattern = '\v,:\zs([^,:]+)' " This patterns finds the wanted
-                                  " item in 'comments'
+let s:pattern = '\v(,[^sme][0-9]*|,|^):\zs[^,]+' " This patterns finds the wanted
+                                         " item in 'comments'
 
 let s:commStart = {} " dict to hold the comment starters using
                      " the current filetype as key
@@ -50,9 +50,10 @@ function! s:Detect_empty_comment()
   endif
   " Captures the comment starter if necessary; only once per filetype
   if !has_key(s:commStart, &ft)
-    let s:commStart[&ft] = matchstr(&comments, s:pattern)
+    let s:commStart[&ft] = join(matchlist(&comments, s:pattern),'q')
   endif
   let line = getline('.')
+  echom s:commStart[&ft]
   if s:commStart[&ft] != '' && line =~ '^\s*\V'. s:commStart[&ft] . '\m\s*$'
     return "\<C-U>"
   else

--- a/plugin/double-tap.vim
+++ b/plugin/double-tap.vim
@@ -35,8 +35,8 @@ endif
 let g:loaded_doubletap = 1
 " }}}
 
-let s:pattern = '\([b,]\|^\):\zs\([^,]\+\)' " This patterns finds the wanted
-                                         " item in 'comments'
+let s:pattern = '\v,:\zs([^,:]+)' " This patterns finds the wanted
+                                  " item in 'comments'
 
 let s:commStart = {} " dict to hold the comment starters using
                      " the current filetype as key


### PR DESCRIPTION
Started working on list scan on the &comments string. 
For now the comments are extracted successfully, however the join() works weird.

While regex extracts every non-multiline comment as it should, join(matchlist()) does not return joined list of matches (duh).

```
comments: s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-
matches (simulated on virex): //,#,%,XCOMM,>
joined (from debug info): //q,qqqqqqqq
```
